### PR TITLE
Add GitHub Action Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: update each level and readme in main
+on:
+  fork:
+  workflow_dispatch:
+    
+jobs:
+  level2:
+    name: advance upstream level2
+    runs-on:
+      ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          ref: level2
+      - name: set up python
+        uses: actions/setup-python@v2
+        with: 
+          python-version: 3.8
+      - name: update readme
+        run: |
+          python .update_readme.py "`date`"
+      - name: commit and push
+        run: |-
+          git config --global user.email "typoverflow@outlook.com"
+          git config --global user.name "typoverflow-bot"
+          git add -A
+          git commit -m ":robot:: Add a new commit" || exit 0
+          git push origin level2
+
+  level3: 
+    name: advance upstream level3
+    runs-on:
+      ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          ref: level3
+      - name: set up python
+        uses: actions/setup-python@v2
+        with: 
+          python-version: 3.8
+      - name:  update readme
+        run: |
+          python .update_readme.py
+      - name: commit and push
+        run: |-
+          git config --global user.email "typoverflow@outlook.com"
+          git config --global user.name "typoverflow-bot"
+          git add -A
+          git commit -m ":robot:: Add a new commit" || exit 0
+          git push origin level3
+


### PR DESCRIPTION
可以参考我的fork目前的分支：level1即为原来的创建一个PR的练习，level2和level3的任务我写在README里了。

具体而言，level2设想的是这样一个场景：当我fork了一个仓库、贡献了部分代码准备PR时，却发现上游分支更新了数个commits。这些commits有可能是和我的修改不冲突的（level2），有可能是冲突的（level3），我需要使用rebase/merge来吸收上游分支中的新改动以PR。

为了实现level2和level3的场景，直接使用了GitHub Action，在监听到fork事件后，Action会向level2分支和level3分支分别推送一个新的commit。

+ [x] 功能测试已通过
+ [ ] 需要你review一下代码
+ [ ] 需要你的仓库创建level1 level2 level3分支以便PR
+ [ ] 任务的语言描述可能还需要改进